### PR TITLE
Fix artifact name attribute in spans

### DIFF
--- a/common/src/main/java/com/octopus/teamcity/opentelemetry/common/PluginConstants.java
+++ b/common/src/main/java/com/octopus/teamcity/opentelemetry/common/PluginConstants.java
@@ -21,7 +21,7 @@ public class PluginConstants {
     public static final String ATTRIBUTE_SUCCESS_STATUS = TRACER_INSTRUMENTATION_NAME + ".success_status";
     public static final String ATTRIBUTE_FAILED_TEST_COUNT = TRACER_INSTRUMENTATION_NAME + ".failed_test_count";
     public static final String ATTRIBUTE_BUILD_PROBLEMS_COUNT = TRACER_INSTRUMENTATION_NAME + ".build_problems_count";
-    public static final String ATTRIBUTE_ARTIFACT_SIZE = TRACER_INSTRUMENTATION_NAME + "_artifact_size";
+    public static final String ATTRIBUTE_ARTIFACT_SIZE = "_artifact_size";
 
     public static final String EVENT_STARTED = "Build Started";
     public static final String EVENT_FINISHED = "Build Finished";


### PR DESCRIPTION
# Background

@cailyoung noticed in the honeycomb spans the attribute for artifacts_size was truncated with artifactName + ".teamcity.opentelemetry_artifact_size". This proved difficult for searching by all artifacts in a build in honeycomb. 

# Results
 
Artifact size attribute now truncated as artifactName + "_artifact_size". This is subject to change in the future. 
