### PR TITLE
Adding parent child relationships to blockMessages

### DIFF
--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/TeamCityBuildListener.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/TeamCityBuildListener.java
@@ -215,11 +215,11 @@ public class TeamCityBuildListener extends BuildServerAdapter {
             if (finishedDate != null) {
                 Span childSpan;
                 if (parentBlockMessage != null) {
-                    // BlockMessage has a parent message
+                    // BlockMessage has a parent message, therefore create a child span referencing that parent
                     Span parentBlockMessageSpan = this.otelHelper.getParentSpan(parentBlockMessage.getText() + parentBlockMessage.getTimestamp());
                     childSpan = this.otelHelper.createChildSpan(parentBlockMessageSpan, buildStepName, blockLogMessage.getTimestamp().getTime());
                 } else {
-                    // BlockMessage does not have a parent message with a span parent to the build
+                    // BlockMessage does not have a parent message, therefore the span will be created span parent span referenced to the build
                     childSpan = this.otelHelper.createChildSpan(span, buildStepName, blockLogMessage.getTimestamp().getTime());
                 }
                 if (blockLogMessage.getBlockDescription() != null) {

--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/TeamCityBuildListener.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/TeamCityBuildListener.java
@@ -215,11 +215,11 @@ public class TeamCityBuildListener extends BuildServerAdapter {
             if (finishedDate != null) {
                 Span childSpan;
                 if (parentBlockMessage != null) {
-                    // BlockMessage has a parent message, therefore create a child span referencing that parent
+                    // BlockMessage has a parent message, create a child span referencing that parent blockMessage span
                     Span parentBlockMessageSpan = this.otelHelper.getParentSpan(parentBlockMessage.getText() + parentBlockMessage.getTimestamp());
                     childSpan = this.otelHelper.createChildSpan(parentBlockMessageSpan, buildStepName, blockLogMessage.getTimestamp().getTime());
                 } else {
-                    // BlockMessage does not have a parent message, therefore the span will be created span parent span referenced to the build
+                    // BlockMessage does not have a parent message, create a child span that will be referencing the build as the parent span.
                     childSpan = this.otelHelper.createChildSpan(span, buildStepName, blockLogMessage.getTimestamp().getTime());
                 }
                 if (blockLogMessage.getBlockDescription() != null) {

--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/TeamCityBuildListener.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/TeamCityBuildListener.java
@@ -207,19 +207,18 @@ public class TeamCityBuildListener extends BuildServerAdapter {
 
     private void createBlockMessageSpans (List<LogMessage> buildBlockLogs, Span span) {
         for (LogMessage logmessage: buildBlockLogs) {
-            BlockLogMessage parentBlockMessage = logmessage.getParent();
             BlockLogMessage blockLogMessage = (BlockLogMessage) logmessage;
             Date finishedDate = blockLogMessage.getFinishDate();
             String buildStepName = blockLogMessage.getText() + blockLogMessage.getTimestamp();
             Loggers.SERVER.debug("OTEL_PLUGIN: Build Step " + buildStepName + " with finish time " + finishedDate);
             if (finishedDate != null) {
+                BlockLogMessage parentBlockMessage = logmessage.getParent();
                 Span childSpan;
                 if (parentBlockMessage != null) {
-                    // BlockMessage has a parent message, create a child span referencing that parent blockMessage span
                     Span parentBlockMessageSpan = this.otelHelper.getParentSpan(parentBlockMessage.getText() + parentBlockMessage.getTimestamp());
                     childSpan = this.otelHelper.createChildSpan(parentBlockMessageSpan, buildStepName, blockLogMessage.getTimestamp().getTime());
                 } else {
-                    // BlockMessage does not have a parent message, create a child span that will be referencing the build as the parent span.
+                    // Use build as the parent span.
                     childSpan = this.otelHelper.createChildSpan(span, buildStepName, blockLogMessage.getTimestamp().getTime());
                 }
                 if (blockLogMessage.getBlockDescription() != null) {


### PR DESCRIPTION
# Background

BlockMessages are used in the plugin to retrieve individual build steps under a build. There was no parent child relationship previously between the blockMessages, where all blockMessages were treated as a child of the build span.

This pull request creates parent child relationships between these blockMessages. I

# Results

If the blockMessage has a parent message, create a child span referencing that parent blockMessage span.
If the blockMessage does not have a parent message, create a child span that will be referencing the build as the parent span.


## Before

Before, all build Steps and blockMessages were a child of the build and flattened. 

## After
After this change, all Build Steps will be nested with reference to a parent message if required.

# How to review this PR

Sanity check my understanding of the blockMessage hierarchy. 

# Pre-requisites
- [x] I have considered informing or consulting the right people