### PR TITLE
Add codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,22 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @global-owner1 and @global-owner2 will be requested for
+# review when someone opens a pull request.
+# *       @global-owner1 @global-owner2
+
+# Order is important; the last matching pattern takes the most
+# precedence. When someone opens a pull request that only
+# modifies JS files, only @js-owner and not the global
+# owner(s) will be requested for a review.
+# *.js    @js-owner
+
+# You can also use email addresses if you prefer. They'll be
+# used to look up users just like we do for commit author
+# emails.
+# *.go docs@example.com
+
+# For more examples see https://help.github.com/articles/about-code-owners/
+* @OctopusDeploy/eng-prod


### PR DESCRIPTION
# Background

@OctopusDeploy/eng-prod is reviewing repos we own and officialising it via codeowners

# Results

This PR adds a codeowners file that sets @OctopusDeploy/eng-prod as codeowners, so that eng-prod is notified on changes to repos we own

# How to review this PR

* :eyes: is fine

# Pre-requisites
- [x] I have considered informing or consulting the right people
- [x] I have considered appropriate testing for my change.