### PR TITLE
Casst/artifact attribute change

### DIFF
--- a/common/src/main/java/com/octopus/teamcity/opentelemetry/common/PluginConstants.java
+++ b/common/src/main/java/com/octopus/teamcity/opentelemetry/common/PluginConstants.java
@@ -23,7 +23,7 @@ public class PluginConstants {
     public static final String ATTRIBUTE_SUCCESS_STATUS = TRACER_INSTRUMENTATION_NAME + ".success_status";
     public static final String ATTRIBUTE_FAILED_TEST_COUNT = TRACER_INSTRUMENTATION_NAME + ".failed_test_count";
     public static final String ATTRIBUTE_BUILD_PROBLEMS_COUNT = TRACER_INSTRUMENTATION_NAME + ".build_problems_count";
-    public static final String ATTRIBUTE_ARTIFACT_SIZE = TRACER_INSTRUMENTATION_NAME + ".artifact.size.";
+    public static final String ATTRIBUTE_TOTAL_ARTIFACT_SIZE = TRACER_INSTRUMENTATION_NAME + ".build_artifacts.total_size";
 
     public static final String EVENT_STARTED = "Build Started";
     public static final String EVENT_FINISHED = "Build Finished";

--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/OTELHelper.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/OTELHelper.java
@@ -42,7 +42,7 @@ public class OTELHelper {
                 .setTracerProvider(sdkTracerProvider)
                 .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
                 .buildAndRegisterGlobal();
-        Loggers.SERVER.info("OTEL_PLUGIN: OTEL_PLUGIN: OpenTelemetry plugin started.");
+        Loggers.SERVER.info("OTEL_PLUGIN: OpenTelemetry plugin started.");
         this.tracer = this.openTelemetry.getTracer(PluginConstants.TRACER_INSTRUMENTATION_NAME);
         this.spanMap = new ConcurrentHashMap<>();
     }

--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/TeamCityBuildListener.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/TeamCityBuildListener.java
@@ -162,7 +162,7 @@ public class TeamCityBuildListener extends BuildServerAdapter {
 
         if(this.otelHelper.getSpan(buildId) != null) {
             Span span = this.otelHelper.getSpan(buildId);
-            Loggers.SERVER.debug("OTEL_PLUGIN: Tracer initialized and span found for " + buildName);
+            Loggers.SERVER.debug("OTEL_PLUGIN: Build finished and span found for " + buildName);
             try (Scope ignored = span.makeCurrent()){
                 createQueuedEventsSpans(build, buildName, span);
                 createBuildStepSpans(build, buildName, span);


### PR DESCRIPTION
# Background

Our dataset in honeycomb had reached the limit for the maximum number of columns (above 10k) and honeycomb blocked anymore incoming data. We have a forever changing column that has the prefix “octopus.teamcity.opentelemetry.artifact.size” with a name field appended that is always changing for each build. 

# Results

An `AtomicLong buildTotalArtifactSize`, is being created on `setArtifactAttributes` method, that increments after each iterated artifact to the total user built artifact size. This is Atomic to handle multiple build threads and be referenced in the lambda function. 

Build artifacts are being filtered by `BuildArtifactsViewMode`. Before we we using `VIEW_ALL` that would return all build artifacts i.e. will include hidden artifacts too. This has been changed to `VIEW_DEFAULT` that will return only all user-published artifacts. 

Once the all artifacts has been iterated and the total sum of artifact size for a build has been calculated, the attribute is added to the span. 

## Before

An attribute that tracked the every single artifact size in a build was being traced via naming the attribute "octopus.teamcity.opentelemetry.artifact.size." + attribute_name

## After

We are now summing the total user built attribute sizes for build and naming a single attribute "octopus.teamcity.opentelemetry.build_artifacts.total_size".

# How to review this PR

Please review logic in above background discussion. 

# Pre-requisites
- [ ] I have considered informing or consulting the right people