### PR TITLE
Build Step Attribute Additions

### DIFF
--- a/common/src/main/java/com/octopus/teamcity/opentelemetry/common/PluginConstants.java
+++ b/common/src/main/java/com/octopus/teamcity/opentelemetry/common/PluginConstants.java
@@ -24,7 +24,7 @@ public class PluginConstants {
     public static final String ATTRIBUTE_FAILED_TEST_COUNT = TRACER_INSTRUMENTATION_NAME + ".failed_test_count";
     public static final String ATTRIBUTE_BUILD_PROBLEMS_COUNT = TRACER_INSTRUMENTATION_NAME + ".build_problems_count";
     public static final String ATTRIBUTE_TOTAL_ARTIFACT_SIZE = TRACER_INSTRUMENTATION_NAME + ".build_artifacts.total_size";
-    public static final String ATTRIBUTE_BUILD_CHECKOUT_TIME = TRACER_INSTRUMENTATION_NAME + ".build_checkout_time_seconds";
+    public static final String ATTRIBUTE_BUILD_CHECKOUT_TIME = TRACER_INSTRUMENTATION_NAME + ".build_checkout_time_ms";
 
     public static final String EVENT_STARTED = "Build Started";
     public static final String EVENT_FINISHED = "Build Finished";

--- a/common/src/main/java/com/octopus/teamcity/opentelemetry/common/PluginConstants.java
+++ b/common/src/main/java/com/octopus/teamcity/opentelemetry/common/PluginConstants.java
@@ -24,6 +24,7 @@ public class PluginConstants {
     public static final String ATTRIBUTE_FAILED_TEST_COUNT = TRACER_INSTRUMENTATION_NAME + ".failed_test_count";
     public static final String ATTRIBUTE_BUILD_PROBLEMS_COUNT = TRACER_INSTRUMENTATION_NAME + ".build_problems_count";
     public static final String ATTRIBUTE_TOTAL_ARTIFACT_SIZE = TRACER_INSTRUMENTATION_NAME + ".build_artifacts.total_size";
+    public static final String ATTRIBUTE_BUILD_CHECKOUT_TIME = TRACER_INSTRUMENTATION_NAME + ".build_checkout_time_seconds";
 
     public static final String EVENT_STARTED = "Build Started";
     public static final String EVENT_FINISHED = "Build Finished";

--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/TeamCityBuildListener.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/TeamCityBuildListener.java
@@ -274,7 +274,7 @@ public class TeamCityBuildListener extends BuildServerAdapter {
             Date checkoutEndDate = blockLogMessage.getFinishDate();
             if (checkoutEndDate != null) {
                 Duration checkoutDuration = Duration.between(checkoutStartDate.toInstant(), checkoutEndDate.toInstant());
-                long checkoutDifference = Math.abs(checkoutDuration.toSeconds());
+                long checkoutDifference = Math.abs(checkoutDuration.toMillis());
                 this.checkoutTimeMap.put(span.getSpanContext().getTraceId(), checkoutDifference);
             }
         }


### PR DESCRIPTION
# Background

To improve usability of honeycomb queries, a request was made to add all attributes from a build span to their subsequent build step spans. 

An additional attribute of `octopus.teamcity.opentelemetry.build_checkout_time_ms` has been calculated and added to only the top level build spans.

# Results

1. A method `setCommonSpanBuildAttributes` now sets the build attributes for all build spans, and build step spans, which includes the queue message and block message types. 
2. Build checkout time is calculated in method `calculateBuildCheckoutTime` from the block message that contains "checkout" in its text. The checkout time is the difference between the timestamp of the msg and the finish time of the message. This is then added to a new concurrent hashmap of the trace id. The attribute for checkout time is then added at the final build finished stage after it has been caculated where the value is retrieved from the concurrent hashmap. 


## Before

Even though the build checkout time could have been visualised in the trace waterfall of a build previously

![Screen Shot 2021-10-04 at 1 20 13 pm](https://user-images.githubusercontent.com/87628019/135784250-65246a85-2d7e-4916-87ea-307b97c7db3c.png)

It is easier to query a builds checkout time if an attribute is added to its span. 

## After

Now build spans have the additional attribute `octopus.teamcity.opentelemetry.build_checkout_time_ms` assigned to them.

![Screen Shot 2021-10-04 at 1 22 21 pm](https://user-images.githubusercontent.com/87628019/135784350-5a79a83e-6cc7-42fa-b5fd-1cf62263cf0d.png)

# How to review this PR

This has been tested locally on a teamcity instance and viewed in honeycomb with required results. 
As all methods are private and open telemetry exporter related, no additional functional unit tests have been added. 

# Pre-requisites
- [ ] I have considered informing or consulting the right people
- [ ] I have considered appropriate testing for my change.