### PR TITLE
upgrade log4j gradle wrapper version to mitigate Log4Shell vulnerability

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -9,11 +9,6 @@ dependencyManagement {
             entry 'common-api'
             entry 'server-api'
         }
-        dependencySet(group: 'org.apache.logging.log4j', version: '2.15.0') {
-            entry 'log4j-api'
-            entry 'log4j-core'
-            entry 'log4j-slf4j-impl'
-        }
         dependency 'org.jetbrains.teamcity:teamcity-rest-client:1.14.0'
         dependency 'com.google.guava:guava:30.1.1-jre'
         dependencySet(group: 'com.google.errorprone', version: '2.7.1') {

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -9,7 +9,7 @@ dependencyManagement {
             entry 'common-api'
             entry 'server-api'
         }
-        dependencySet(group: 'org.apache.logging.log4j', version: '2.14.1') {
+        dependencySet(group: 'org.apache.logging.log4j', version: '2.15.0') {
             entry 'log4j-api'
             entry 'log4j-core'
             entry 'log4j-slf4j-impl'


### PR DESCRIPTION
# Background

Due to Log4Shell vulnerability 

# Results

Upgrading the log4j package version in gradle wrapper to patched version.

# Pre-requisites
- [x] I have considered informing or consulting the right people
- [x] I have considered appropriate testing for my change.