### PR TITLE
Add span attribute for build step status

### DIFF
--- a/common/src/main/java/com/octopus/teamcity/opentelemetry/common/PluginConstants.java
+++ b/common/src/main/java/com/octopus/teamcity/opentelemetry/common/PluginConstants.java
@@ -13,6 +13,7 @@ public class PluginConstants {
     public static final String ATTRIBUTE_NAME = "name";
     public static final String ATTRIBUTE_BUILD_TYPE_ID = TRACER_INSTRUMENTATION_NAME + ".build_type_id";
     public static final String ATTRIBUTE_BUILD_TYPE_EXTERNAL_ID = TRACER_INSTRUMENTATION_NAME + ".build_type_external_id";
+    public static final String ATTRIBUTE_BUILD_STEP_STATUS = TRACER_INSTRUMENTATION_NAME + ".build_step_status";
     public static final String ATTRIBUTE_PROJECT_NAME = TRACER_INSTRUMENTATION_NAME + ".project_name";
     public static final String ATTRIBUTE_PROJECT_ID = TRACER_INSTRUMENTATION_NAME + ".project_id";
     public static final String ATTRIBUTE_AGENT_NAME = TRACER_INSTRUMENTATION_NAME + ".agent_name";

--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/TeamCityBuildListener.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/TeamCityBuildListener.java
@@ -239,6 +239,7 @@ public class TeamCityBuildListener extends BuildServerAdapter {
                 parentSpan = buildSpan;
             }
             Span childSpan = this.otelHelper.createTransientSpan(blockMessageStepName, parentSpan, blockLogMessage.getTimestamp().getTime());
+            otelHelper.addAttributeToSpan(childSpan, PluginConstants.ATTRIBUTE_BUILD_STEP_STATUS, blockLogMessage.getStatus());
             blockMessageSpanMap.put(blockMessageStepName, childSpan);
             Loggers.SERVER.debug("OTEL_PLUGIN: Build step span added for " + blockMessageStepName);
             String spanName;


### PR DESCRIPTION
# Background

We want to use a teamcity build as a litmus test to make sure our build platform is working.
We've setup the build as a simple sequence of steps (that always run, even if prior ones have failed), but we're not currently seeing the build step status showing up.

# Results

This PR adds the build step status as a new field called `octopus.teamcity.opentelemetry.build_step_status`

## After

![Screen Shot 2022-05-25 at 5 02 54 pm](https://user-images.githubusercontent.com/87628019/170200884-463903fc-6781-4e7a-bdf2-6f86c41a8175.png)

Potential Status of steps:
```
ERROR
FAILURE
NORMAL
UNKNOWN
WARNING
```

[Docs](https://javadoc.jetbrains.net/teamcity/openapi/8.0/jetbrains/buildServer/messages/Status.html) for step statuses. 


# How to review this PR

* we swarmed on this and tested it while pairing so it will be fine with a quick :eyes:

# Pre-requisites
- [x] I have considered informing or consulting the right people
- [x] I have considered appropriate testing for my change.