### PR TITLE
Create a dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 1


### PR DESCRIPTION
# Background

We want to make sure we're updating dependencies to avoid bit rot and vulnerabilities caused by out of date dependency issues.

# Results

This PR adds the dependabot config to keep our gradle config up to date.

# How to review this PR

* eyes should be fine.

# Pre-requisites
- [x] I have considered informing or consulting the right people
- [x] I have considered appropriate testing for my change.