### PR TITLE
Log to our own plugin specific file

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,30 @@ From the [OpenTelemetry docs](https://opentelemetry.io/docs/):
 4. Note that settings are inherited and can be overridden by child project settings
 5. Install the .zip using your TeamCity instance UI via Administration -> Plugins -> Upload. Restart if required.
 
+### Logging
+
+To view logs from the plugin, add the following sections to the `conf/teamcity-server-log4j.xml` file in your teamcity installation:
+
+Under `Appenders`:
+```xml
+    <DelegateAppender>
+      <RollingFile name="OTEL.LOG" fileName="${sys:teamcity_logs}/teamcity-otel-plugin.log"
+                   filePattern="${sys:teamcity_logs}/teamcity-otel-plugin.log.%i"
+                   append="true" createOnDemand="true">
+        <PatternLayout pattern="[%d] %6p - %30.30c - %m%n" charset="UTF-8"/>
+        <SizeBasedTriggeringPolicy size="10 MB"/>
+        <DefaultRolloverStrategy max="3" fileIndex="min"/>
+      </RollingFile>
+    </DelegateAppender>
+```
+
+Under `Loggers`:
+```xml
+    <Logger name="com.octopus.teamcity.opentelemetry" level="DEBUG">
+      <AppenderRef ref="OTEL.LOG" />
+    </Logger>
+```
+
 ## Local Development
 
 ### Using Docker

--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/BuildStorageManagerImpl.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/BuildStorageManagerImpl.java
@@ -3,6 +3,7 @@ package com.octopus.teamcity.opentelemetry.server;
 import jetbrains.buildServer.serverSide.SBuild;
 import jetbrains.buildServer.serverSide.SRunningBuild;
 import jetbrains.buildServer.log.Loggers;
+import org.apache.log4j.Logger;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -12,7 +13,7 @@ import java.io.IOException;
 import java.util.Scanner;
 
 public class BuildStorageManagerImpl implements BuildStorageManager {
-
+    static Logger LOG = Logger.getLogger(BuildStorageManagerImpl.class.getName());
     public static final String OTEL_TRACE_ID_FILENAME = "otel-trace-id";
 
     @Override
@@ -21,19 +22,19 @@ public class BuildStorageManagerImpl implements BuildStorageManager {
         File artifactsDir = build.getArtifactsDirectory();
         File pluginFile = new File(artifactsDir, jetbrains.buildServer.ArtifactsConstants.TEAMCITY_ARTIFACTS_DIR + File.separatorChar + OTEL_TRACE_ID_FILENAME);
 
-        Loggers.SERVER.debug(String.format("OTEL_PLUGIN: Reading trace id or build %d.", build.getBuildId()));
+        LOG.debug(String.format("Reading trace id or build %d.", build.getBuildId()));
 
         if (!pluginFile.exists()) {
-            Loggers.SERVER.info(String.format("OTEL_PLUGIN: Unable to find build artifact %s for build %d.", OTEL_TRACE_ID_FILENAME, build.getBuildId()));
+            LOG.info(String.format("Unable to find build artifact %s for build %d.", OTEL_TRACE_ID_FILENAME, build.getBuildId()));
             return null;
         }
 
         String traceId;
         try (Scanner fileReader = new Scanner(pluginFile)) {
             traceId = fileReader.nextLine();
-            Loggers.SERVER.debug(String.format("OTEL_PLUGIN: Retrieved trace id %s for build %d.", traceId, build.getBuildId()));
+            LOG.debug(String.format("Retrieved trace id %s for build %d.", traceId, build.getBuildId()));
         } catch (FileNotFoundException e) {
-            Loggers.SERVER.warn(String.format("OTEL_PLUGIN: Unable to find trace id data file for build %d.", build.getBuildId()));
+            LOG.warn(String.format("Unable to find trace id data file for build %d.", build.getBuildId()));
             return null;
         }
         return traceId;
@@ -43,11 +44,11 @@ public class BuildStorageManagerImpl implements BuildStorageManager {
     public void saveTraceId(SRunningBuild build, String traceId) {
         File artifactsDir = build.getArtifactsDirectory();
         File pluginFile = new File(artifactsDir, jetbrains.buildServer.ArtifactsConstants.TEAMCITY_ARTIFACTS_DIR + File.separatorChar + OTEL_TRACE_ID_FILENAME);
-        Loggers.SERVER.debug(String.format("OTEL_PLUGIN: Saving trace id %s to %s for build %d.", traceId, OTEL_TRACE_ID_FILENAME, build.getBuildId()));
+        LOG.debug(String.format("Saving trace id %s to %s for build %d.", traceId, OTEL_TRACE_ID_FILENAME, build.getBuildId()));
         try (FileWriter fileWriter = new FileWriter(pluginFile)) {
             fileWriter.write(traceId);
         } catch (IOException e) {
-            Loggers.SERVER.warn(String.format("OTEL_PLUGIN: Error trying to save trace id for build %d.", build.getBuildId()));
+            LOG.warn(String.format("Error trying to save trace id for build %d.", build.getBuildId()));
         }
     }
 }

--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/ProjectConfigurationSettingsController.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/ProjectConfigurationSettingsController.java
@@ -9,6 +9,7 @@ import jetbrains.buildServer.serverSide.crypt.EncryptUtil;
 import jetbrains.buildServer.serverSide.crypt.RSACipher;
 import jetbrains.buildServer.util.StringUtil;
 import jetbrains.buildServer.web.openapi.WebControllerManager;
+import org.apache.log4j.Logger;
 import org.jdom.Element;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.web.servlet.ModelAndView;
@@ -23,6 +24,7 @@ import static com.octopus.teamcity.opentelemetry.common.PluginConstants.*;
 public class ProjectConfigurationSettingsController extends BaseFormXmlController {
     @NotNull
     private final ProjectManager projectManager;
+    static Logger LOG = Logger.getLogger(ProjectConfigurationSettingsController.class.getName());
 
     public ProjectConfigurationSettingsController(
             @NotNull ProjectManager projectManager,
@@ -66,7 +68,7 @@ public class ProjectConfigurationSettingsController extends BaseFormXmlControlle
                 project.persist();
                 getOrCreateMessages(request).addMessage("featureReset", "Feature was reset to the inherited settings.");
             } else {
-                Loggers.SERVER.warn(String.format("OTEL_PLUGIN: Got a request to reset settings, but the settings didn't exist on project %s?", project.getProjectId()));
+                LOG.warn(String.format("Got a request to reset settings, but the settings didn't exist on project %s?", project.getProjectId()));
             }
         } else {
             if (feature.isEmpty()) {

--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/helpers/HelperPerBuildOTELHelperFactory.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/helpers/HelperPerBuildOTELHelperFactory.java
@@ -1,10 +1,11 @@
 package com.octopus.teamcity.opentelemetry.server.helpers;
 
-import jetbrains.buildServer.log.Loggers;
 import com.octopus.teamcity.opentelemetry.server.OTELService;
 import jetbrains.buildServer.serverSide.BuildPromotion;
 import jetbrains.buildServer.serverSide.ProjectManager;
 import jetbrains.buildServer.serverSide.crypt.EncryptUtil;
+import org.apache.log4j.Logger;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -12,6 +13,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import static com.octopus.teamcity.opentelemetry.common.PluginConstants.*;
 
 public class HelperPerBuildOTELHelperFactory implements OTELHelperFactory {
+    static Logger LOG = Logger.getLogger(HelperPerBuildOTELHelperFactory.class.getName());
     private final ConcurrentHashMap<Long, OTELHelper> otelHelpers;
     private final ProjectManager projectManager;
 
@@ -19,16 +21,17 @@ public class HelperPerBuildOTELHelperFactory implements OTELHelperFactory {
         ProjectManager projectManager
     ) {
         this.projectManager = projectManager;
-        Loggers.SERVER.debug("OTEL_PLUGIN: Creating HelperPerBuildOTELHelperFactory.");
+        LOG.debug("Creating HelperPerBuildOTELHelperFactory.");
 
         this.otelHelpers = new ConcurrentHashMap<>();
     }
 
     public OTELHelper getOTELHelper(BuildPromotion build) {
         var buildId = build.getId();
-        Loggers.SERVER.debug(String.format("OTEL_PLUGIN: Getting OTELHelper for build %d.", buildId));
+        LOG.debug(String.format("Getting OTELHelper for build %d.", buildId));
+
         return otelHelpers.computeIfAbsent(buildId, key -> {
-            Loggers.SERVER.debug(String.format("OTEL_PLUGIN: Creating OTELHelper for build %d.", buildId));
+            LOG.debug(String.format("Creating OTELHelper for build %d.", buildId));
             var projectId = build.getProjectExternalId();
             var project = projectManager.findProjectByExternalId(projectId);
 
@@ -57,12 +60,12 @@ public class HelperPerBuildOTELHelperFactory implements OTELHelperFactory {
                     long endTime = System.nanoTime();
 
                     long duration = (endTime - startTime);
-                    Loggers.SERVER.debug(String.format("OTEL_PLUGIN: Created OTELHelper for build %d in %d milliseconds.", buildId, duration / 1000000));
+                    LOG.debug(String.format("Created OTELHelper for build %d in %d milliseconds.", buildId, duration / 1000000));
 
                     return otelHelper;
                 }
             }
-            Loggers.SERVER.debug(String.format("OTEL_PLUGIN: Using NullOTELHelper for build %d.", buildId));
+            LOG.debug(String.format("Using NullOTELHelper for build %d.", buildId));
             return new NullOTELHelperImpl();
         });
     }

--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/helpers/OTELHelperImpl.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/helpers/OTELHelperImpl.java
@@ -19,13 +19,14 @@ import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
 import jetbrains.buildServer.log.Loggers;
+import org.apache.log4j.Logger;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
 public class OTELHelperImpl implements OTELHelper {
-
+    static Logger LOG = Logger.getLogger(OTELHelperImpl.class.getName());
     private final OpenTelemetry openTelemetry;
     private final Tracer tracer;
     private final ConcurrentHashMap<String, Span> spanMap;
@@ -43,7 +44,7 @@ public class OTELHelperImpl implements OTELHelper {
                 .setTracerProvider(sdkTracerProvider)
                 .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
                 .build();
-        Loggers.SERVER.info("OTEL_PLUGIN: OpenTelemetry plugin started.");
+        LOG.info("OpenTelemetry plugin started.");
         this.tracer = this.openTelemetry.getTracer(PluginConstants.TRACER_INSTRUMENTATION_NAME);
         this.spanMap = new ConcurrentHashMap<>();
     }
@@ -54,8 +55,8 @@ public class OTELHelperImpl implements OTELHelper {
         spanExporterBuilder.setEndpoint(exporterEndpoint);
         SpanExporter spanExporter = spanExporterBuilder.build();
 
-        Loggers.SERVER.debug("OTEL_PLUGIN: Opentelemetry export headers: " + LogMasker.mask(headers.toString()));
-        Loggers.SERVER.debug("OTEL_PLUGIN: Opentelemetry export endpoint: " + exporterEndpoint);
+        LOG.debug("Opentelemetry export headers: " + LogMasker.mask(headers.toString()));
+        LOG.debug("Opentelemetry export endpoint: " + exporterEndpoint);
 
         return BatchSpanProcessor.builder(spanExporter).build();
     }
@@ -72,7 +73,7 @@ public class OTELHelperImpl implements OTELHelper {
 
     @Override
     public Span createSpan(String spanName, Span parentSpan) {
-        Loggers.SERVER.info("OTEL_PLUGIN: Creating child span " + spanName + " under parent " + parentSpan);
+        LOG.info("Creating child span " + spanName + " under parent " + parentSpan);
         return this.spanMap.computeIfAbsent(spanName, key -> this.tracer.spanBuilder(spanName).setParent(Context.current().with(parentSpan)).startSpan());
     }
 
@@ -93,7 +94,7 @@ public class OTELHelperImpl implements OTELHelper {
 
     @Override
     public void addAttributeToSpan(Span span, String attributeName, Object attributeValue) {
-        Loggers.SERVER.debug("OTEL_PLUGIN: Adding attribute to span " + attributeName + "=" + attributeValue);
+        LOG.debug("Adding attribute to span " + attributeName + "=" + attributeValue);
         span.setAttribute(attributeName, attributeValue.toString());
     }
 }


### PR DESCRIPTION
Rather than the server log

# Background

We were in a bit of an icky spot with logging - we were logging to the main server log file, rather than our own specific log file, meaning it was hard to find our logs, but also we were polluting the main server log with too much info.

# Results

We now log to our own file. 
Instructions are provided as to how setup TeamCity logging.

# How to review this PR

* eyes should be fine
* does the readme change make sense?

# Pre-requisites
- [x] I have considered informing or consulting the right people
- [x] I have considered appropriate testing for my change.