### PR TITLE
Cleanup the otelHelper after we've finished

### DIFF
--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/TeamCityBuildListener.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/TeamCityBuildListener.java
@@ -164,7 +164,7 @@ public class TeamCityBuildListener extends BuildServerAdapter {
                     span.end();
                     var buildId = getBuildId(build);
                     otelHelper.removeSpan(buildId);
-                    if (buildId.equals(String.valueOf(getRootBuildInChain(build))))
+                    if (buildId.equals(String.valueOf(getRootBuildInChain(build).getId())))
                         otelHelperFactory.release(build.getBuildId());
                 }
             } else {

--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/helpers/HelperPerBuildOTELHelperFactory.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/helpers/HelperPerBuildOTELHelperFactory.java
@@ -107,6 +107,10 @@ public class HelperPerBuildOTELHelperFactory implements OTELHelperFactory {
 
     @Override
     public void release(Long buildId) {
-        otelHelpers.remove(buildId);
+        var helper = otelHelpers.get(buildId);
+        if (helper != null) {
+            helper.release();
+            otelHelpers.remove(buildId);
+        }
     }
 }

--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/helpers/NullOTELHelperImpl.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/helpers/NullOTELHelperImpl.java
@@ -35,4 +35,8 @@ public class NullOTELHelperImpl implements OTELHelper {
     @Override
     public void addAttributeToSpan(Span span, String attributeName, Object attributeValue) {
     }
+
+    @Override
+    public void release() {
+    }
 }

--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/helpers/OTELHelper.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/helpers/OTELHelper.java
@@ -37,4 +37,6 @@ public interface OTELHelper {
     Span getSpan(String buildId);
 
     void addAttributeToSpan(Span span, String attributeName, Object attributeValue);
+
+    void release();
 }

--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/helpers/OTELHelperImpl.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/helpers/OTELHelperImpl.java
@@ -81,5 +81,6 @@ public class OTELHelperImpl implements OTELHelper {
     public void release() {
         this.sdkTracerProvider.forceFlush();
         this.sdkTracerProvider.close();
+        this.spanMap.clear();
     }
 }

--- a/server/src/test/java/com/octopus/teamcity/opentelemetry/server/TeamCityBuildListenerTest.java
+++ b/server/src/test/java/com/octopus/teamcity/opentelemetry/server/TeamCityBuildListenerTest.java
@@ -101,4 +101,22 @@ class TeamCityBuildListenerTest {
         // Assert
         assertNull(this.otelHelper.getSpan(String.valueOf(build.getBuildId())));
     }
+
+    @Test
+    void buildFinishedOrInterruptedAsksFactoryToRelease() {
+        // Arrange
+        SRunningBuild build = mock(SRunningBuild.class, RETURNS_DEEP_STUBS);
+        // Stubbing this method to return the build if there is no parent, this is the behaviour of TeamCity
+        BuildPromotion[] buildPromotions = new BuildPromotion[]{build.getBuildPromotion()};
+        when(build.getBuildPromotion().findTops()).thenReturn(buildPromotions);
+        when(factory.getOTELHelper(Arrays.stream(buildPromotions).findFirst().get())).thenReturn(otelHelper);
+        this.buildListener.buildStarted(build);
+        assertNotNull(this.otelHelper.getSpan(String.valueOf(build.getBuildId())));
+
+        // Act
+        this.buildListener.buildFinished(build);
+
+        // Assert
+        verify(factory, times(1)).release(build.getBuildId());
+    }
 }


### PR DESCRIPTION
# Background

We had a bit of an issue where we weren't releasing objects, so we need up with 25,000 threads in use, along with a growing number of 5XX errors being returned, slow performance, and excessive memory utilisation.

# Results

Fixes https://github.com/OctopusDeploy/opentelemetry-teamcity-plugin/issues/29

We now remove the `OTELHelper` from the lookup dictionary when we've finished with it.

# How to review this PR

I've tested this locally, and seen that it removes it from the dictionary at the end of the build as expected.
A local test would be nice, but not mandatory.

# Pre-requisites
- [x] I have considered informing or consulting the right people
- [x] I have considered appropriate testing for my change.