### PR TITLE
Add padding under the link so that build problems show nicely

### DIFF
--- a/server/src/main/resources/buildServerResources/buildOverviewHoneycombExtension.jsp
+++ b/server/src/main/resources/buildServerResources/buildOverviewHoneycombExtension.jsp
@@ -1,7 +1,7 @@
 <%@ include file="/include.jsp"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
 
-<a href="https://ui.honeycomb.io/${team}/datasets/${dataset}/trace?trace_id=${traceId}&trace_start_ts=${buildStart}&trace_end_ts=${buildEnd}">
+<a href="https://ui.honeycomb.io/${team}/datasets/${dataset}/trace?trace_id=${traceId}&trace_start_ts=${buildStart}&trace_end_ts=${buildEnd}" style="display: block; margin-bottom: 30px;">
     <svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 107.51 102" style="height: 20px; vertical-align: top;">
         <defs>
             <style>.cls-1{fill:#25303e;}.cls-2{fill:#ffb000;}.cls-3{fill:#64ba00;}.cls-4{fill:#f96e10;}.cls-5{fill:#0298ec;}</style>

--- a/server/src/main/resources/buildServerResources/buildOverviewZipkinExtension.jsp
+++ b/server/src/main/resources/buildServerResources/buildOverviewZipkinExtension.jsp
@@ -1,7 +1,7 @@
 <%@ include file="/include.jsp"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
 
-<a href="${endpoint}/zipkin/traces/${traceId}">
+<a href="${endpoint}/zipkin/traces/${traceId}" style="display: block; margin-bottom: 30px;">
     <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 418 442" style="height: 20px; vertical-align: top;">
         <g>
             <g>


### PR DESCRIPTION
# Background

Previously, when builds had problems, the link and the build problems were jammed together - it didn't look pretty.

![image](https://user-images.githubusercontent.com/373389/184821065-03af55b5-923b-4989-a9c2-f94d2dc4502b.png)


# Results

We now stick a bucket load (that's a technical term right there) of spacing underneath it:

![image](https://user-images.githubusercontent.com/373389/184820678-5caebcdc-f20a-4a10-a0a4-13ce036c0660.png)

# How to review this PR

* eyeballs will be fine

# Pre-requisites
- [x] I have considered informing or consulting the right people
- [x] I have considered appropriate testing for my change.