### PR TITLE
Bump teamcity sdk from 2020.2 to 2022.10

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -5,7 +5,7 @@ dependencyManagement {
         dependency 'org.junit.jupiter:junit-jupiter-params:5.6.0'
         dependency 'org.assertj:assertj-core:3.18.1'
         dependency 'com.google.code.gson:gson:2.2.2'
-        dependencySet(group: 'org.jetbrains.teamcity', version: '2020.2') {
+        dependencySet(group: 'org.jetbrains.teamcity', version: '2022.10') {
             entry 'common-api'
             entry 'server-api'
         }


### PR DESCRIPTION
# Background

Ever since upgrading to teamcity 2022.10, we've been seeing lots of errors like:
![image](https://user-images.githubusercontent.com/373389/211737013-cb009979-5f53-4ac8-a215-97c10835a428.png)

This mainly seems to happen on transition from queued -> running.

# Results

This bumps the SDK to 2022.10 to see if that helps

<!-- Describe the result of the change including a link to any resolved issues. -->

Fixes https://github.com/OctopusDeploy/opentelemetry-teamcity-plugin /issues/...

<!-- Consider adding a before/after log excerpt or screen capture. -->

## Before


## After


# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

# Pre-requisites
- [ ] I have considered informing or consulting the right people
- [ ] I have considered appropriate testing for my change.