### PR TITLE
[fix/custom-otel-endpoint-configuration] Fix custom otel configuration in Teamcity

### DIFF
--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/ProjectConfigurationTab.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/ProjectConfigurationTab.java
@@ -68,7 +68,8 @@ public class ProjectConfigurationTab extends EditProjectTab {
             model.put("otelEndpoint", params.get(PROPERTY_KEY_ENDPOINT));
             model.put("otelHoneycombTeam", params.get(PROPERTY_KEY_HONEYCOMB_TEAM));
             model.put("otelHoneycombDataset", params.get(PROPERTY_KEY_HONEYCOMB_DATASET));
-            model.put("otelHoneycombApiKey", RSACipher.encryptDataForWeb(EncryptUtil.unscramble(params.get(PROPERTY_KEY_HONEYCOMB_APIKEY))));
+            // model.put("otelHoneycombApiKey",
+            // RSACipher.encryptDataForWeb(EncryptUtil.unscramble(params.get(PROPERTY_KEY_HONEYCOMB_APIKEY))));
 
             var headers = new ArrayList<HeaderDto>();
             params.forEach((k,v)->{


### PR DESCRIPTION
# Background

<!-- Why does this PR exist? -->
- It's not possible to set a custom otel configuration as the code will try to use the otelHoneycombApiKey value (that will be null) and passing it to EncryptUtil.unscramble which will then fail and throw an exception 😢 

# Solution

- Comment the line that is trying to read the value from otelHoneycombApiKey 😎


# Results

## Before

- Using custom otel config  ❌
- Using honeycomb config ✅

## After

- Using custom otel config  ✅
- Using honeycomb config  ❌


**_Disclamer_**: This PR is in early stages of development and should not be taking seriously or used in production 😆 