### PR TITLE
Don't try and unscramble an empty value

### DIFF
--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/ProjectConfigurationTab.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/ProjectConfigurationTab.java
@@ -68,7 +68,12 @@ public class ProjectConfigurationTab extends EditProjectTab {
             model.put("otelEndpoint", params.get(PROPERTY_KEY_ENDPOINT));
             model.put("otelHoneycombTeam", params.get(PROPERTY_KEY_HONEYCOMB_TEAM));
             model.put("otelHoneycombDataset", params.get(PROPERTY_KEY_HONEYCOMB_DATASET));
-            model.put("otelHoneycombApiKey", RSACipher.encryptDataForWeb(EncryptUtil.unscramble(params.get(PROPERTY_KEY_HONEYCOMB_APIKEY))));
+            if (params.get(PROPERTY_KEY_HONEYCOMB_APIKEY) == null) {
+                model.put("otelHoneycombApiKey", null);
+            }
+            else {
+                model.put("otelHoneycombApiKey", RSACipher.encryptDataForWeb(EncryptUtil.unscramble(params.get(PROPERTY_KEY_HONEYCOMB_APIKEY))));
+            }
 
             var headers = new ArrayList<HeaderDto>();
             params.forEach((k,v)->{


### PR DESCRIPTION
# Background

A bug was reported that when trying to use NewRelic as a `custom` service, it crashes with

```
java.lang.reflect.InvocationTargetException: null
	at jdk.internal.reflect.GeneratedMethodAccessor194.invoke(Unknown Source) ~[?:?]
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
	at java.lang.reflect.Method.invoke(Method.java:566) ~[?:?]
	at jetbrains.buildServer.web.impl.PagePlaceImpl$ProxyHandler.invokeExtensionMethodUnsafe(PagePlaceImpl.java:21) ~[web.jar:?]
	at jetbrains.buildServer.web.impl.PagePlaceImpl$ProxyHandler.invoke(PagePlaceImpl.java:4) ~[web.jar:?]
	at com.sun.proxy.$Proxy93.fillModel(Unknown Source) ~[?:?]
	at jetbrains.buildServer.web.impl.PageExtensionsInterceptor.fillModel(PageExtensionsInterceptor.java:85) ~[web.jar:?]
	at jetbrains.buildServer.web.impl.PageExtensionsInterceptor.processCustomTabs(PageExtensionsInterceptor.java:66) ~[web.jar:?]
	at jetbrains.buildServer.web.impl.PageExtensionsInterceptor.fillModel(PageExtensionsInterceptor.java:101) ~[web.jar:?]
	at jetbrains.buildServer.web.impl.PageExtensionsInterceptor.postHandle(PageExtensionsInterceptor.java:100) ~[web.jar:?]
	at org.springframework.web.servlet.HandlerExecutionChain.applyPostHandle(HandlerExecutionChain.java:165) ~[spring-webmvc.jar:5.3.18]
	at org.springframework.web.servlet.DispatcherServlet.doDispatch(DispatcherServlet.java:1074) ~[spring-webmvc.jar:5.3.18]
	at org.springframework.web.servlet.DispatcherServlet.doService(DispatcherServlet.java:963) ~[spring-webmvc.jar:5.3.18]
	at jetbrains.buildServer.maintenance.WebDispatcherServlet.doService(WebDispatcherServlet.java:38) ~[web.jar:?]
	at org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:1006) ~[spring-webmvc.jar:5.3.18]
	at org.springframework.web.servlet.FrameworkServlet.doGet(FrameworkServlet.java:898) ~[spring-webmvc.jar:5.3.18]
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:655) ~[servlet-api.jar:?]
	at org.springframework.web.servlet.FrameworkServlet.service(FrameworkServlet.java:883) ~[spring-webmvc.jar:5.3.18]
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:764) ~[servlet-api.jar:?]
	at jetbrains.buildServer.maintenance.TeamCityDispatcherServlet.processedByMainServlet(TeamCityDispatcherServlet.java:28) ~[web.jar:?]
	at jetbrains.buildServer.maintenance.TeamCityDispatcherServlet.service(TeamCityDispatcherServlet.java:24) ~[web.jar:?]
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:231) ~[catalina.jar:8.5.78]
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166) ~[catalina.jar:8.5.78]
	at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:52) ~[tomcat-websocket.jar:8.5.78]
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193) ~[catalina.jar:8.5.78]
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166) ~[catalina.jar:8.5.78]
	at jetbrains.buildServer.web.jsp.JspPrecompilerFilter.doFilter(JspPrecompilerFilter.java:122) ~[web.jar:?]
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193) ~[catalina.jar:8.5.78]
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166) ~[catalina.jar:8.5.78]
	at jetbrains.buildServer.web.DisableSessionIdFromUrlFilter.doFilter(DisableSessionIdFromUrlFilter.java:1) ~[web.jar:?]
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193) ~[catalina.jar:8.5.78]
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166) ~[catalina.jar:8.5.78]
	at jetbrains.buildServer.web.UserIdProviderFilter.doFilter(UserIdProviderFilter.java:2) ~[web.jar:?]
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193) ~[catalina.jar:8.5.78]
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166) ~[catalina.jar:8.5.78]
	at jetbrains.buildServer.web.BannedIPsFilter.doFilter(BannedIPsFilter.java:1) ~[web.jar:?]
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193) ~[catalina.jar:8.5.78]
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166) ~[catalina.jar:8.5.78]
	at jetbrains.buildServer.web.NodeInfoHeaderFilter.doFilter(NodeInfoHeaderFilter.java:4) ~[web.jar:?]
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193) ~[catalina.jar:8.5.78]
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166) ~[catalina.jar:8.5.78]
	at org.springframework.web.filter.CompositeFilter$VirtualFilterChain.doFilter(CompositeFilter.java:108) ~[spring-webmvc.jar:5.3.18]
	at jetbrains.buildServer.diagnostic.web.DiagnosticFilter.doFilter(DiagnosticFilter.java:15) ~[web.jar:?]
	at org.springframework.web.filter.CompositeFilter$VirtualFilterChain.doFilter(CompositeFilter.java:113) ~[spring-webmvc.jar:5.3.18]
	at jetbrains.buildServer.web.DependencyParametersCalculationContextFilter.doFilter(DependencyParametersCalculationContextFilter.java:4) ~[web.jar:?]
	at org.springframework.web.filter.CompositeFilter$VirtualFilterChain.doFilter(CompositeFilter.java:113) ~[spring-webmvc.jar:5.3.18]
	at jetbrains.buildServer.diagnostic.web.HttpRequestsDurationMetricsReporter.doFilter(HttpRequestsDurationMetricsReporter.java:9) ~[web.jar:?]
	at org.springframework.web.filter.CompositeFilter$VirtualFilterChain.doFilter(CompositeFilter.java:113) ~[spring-webmvc.jar:5.3.18]
	at jetbrains.buildServer.web.HttpSecurityHeadersFilter.doFilter(HttpSecurityHeadersFilter.java:119) ~[web.jar:?]
	at org.springframework.web.filter.CompositeFilter$VirtualFilterChain.doFilter(CompositeFilter.java:113) ~[spring-webmvc.jar:5.3.18]
	at jetbrains.buildServer.controllers.filters.DisableSessionCookieTokenAuthFilter.doFilter(DisableSessionCookieTokenAuthFilter.java:8) ~[web.jar:?]
	at org.springframework.web.filter.CompositeFilter$VirtualFilterChain.doFilter(CompositeFilter.java:113) ~[spring-webmvc.jar:5.3.18]
	at jetbrains.buildServer.controllers.filters.ProxyDetailsFilter.doFilter(ProxyDetailsFilter.java:14) ~[web.jar:?]
	at org.springframework.web.filter.CompositeFilter$VirtualFilterChain.doFilter(CompositeFilter.java:113) ~[spring-webmvc.jar:5.3.18]
	at jetbrains.buildServer.controllers.filters.ClearSecurityContextFilter.doFilter(ClearSecurityContextFilter.java:7) ~[web.jar:?]
	at org.springframework.web.filter.CompositeFilter$VirtualFilterChain.doFilter(CompositeFilter.java:113) ~[spring-webmvc.jar:5.3.18]
	at org.springframework.web.filter.CompositeFilter.doFilter(CompositeFilter.java:74) ~[spring-webmvc.jar:5.3.18]
	at jetbrains.buildServer.web.DelegatingFilter.doFilter(DelegatingFilter.java:74) ~[server-api.jar:?]
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193) ~[catalina.jar:8.5.78]
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166) ~[catalina.jar:8.5.78]
	at jetbrains.buildServer.web.ResponseFragmentFilter.doFilter(ResponseFragmentFilter.java:18) ~[web.jar:?]
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193) ~[catalina.jar:8.5.78]
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166) ~[catalina.jar:8.5.78]
	at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:197) ~[catalina.jar:8.5.78]
	at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:97) ~[catalina.jar:8.5.78]
	at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:543) ~[catalina.jar:8.5.78]
	at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:135) ~[catalina.jar:8.5.78]
	at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:92) ~[catalina.jar:8.5.78]
	at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:78) ~[catalina.jar:8.5.78]
	at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:367) ~[catalina.jar:8.5.78]
	at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:639) ~[tomcat-coyote.jar:8.5.78]
	at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:65) ~[tomcat-coyote.jar:8.5.78]
	at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:882) ~[tomcat-coyote.jar:8.5.78]
	at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1647) ~[tomcat-coyote.jar:8.5.78]
	at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:49) ~[tomcat-coyote.jar:8.5.78]
	at org.apache.tomcat.util.threads.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1191) ~[tomcat-util.jar:8.5.78]
	at org.apache.tomcat.util.threads.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:659) ~[tomcat-util.jar:8.5.78]
	at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61) ~[tomcat-util.jar:8.5.78]
	at java.lang.Thread.run(Thread.java:829) ~[?:?]
Caused by: java.lang.NullPointerException
	at jetbrains.buildServer.serverSide.crypt.EncryptUtil.unscramble(EncryptUtil.java:143) ~[common-api.jar:?]
	at com.octopus.teamcity.opentelemetry.server.ProjectConfigurationTab.fillModel(ProjectConfigurationTab.java:71) ~[?:?]
	... 79 more
```

This is because it's trying to decrypt the honeycomb api key every time, even it it's null.

This is a "proper" version of #135 (cc @fantun3s)

# Results

This PR adds a null check around the offending line\.

## Before

Crash. Much sadness.

## After

No crash. Happyness.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

# Pre-requisites
- [ ] I have considered informing or consulting the right people
- [ ] I have considered appropriate testing for my change.