### PR TITLE
Test processing issue.

### DIFF
--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/TeamCityBuildListener.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/TeamCityBuildListener.java
@@ -39,9 +39,9 @@ public class TeamCityBuildListener extends BuildServerAdapter {
     @Autowired
     @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
     public TeamCityBuildListener(
-            EventDispatcher<BuildServerListener> buildServerListenerEventDispatcher,
-            OTELHelperFactory otelHelperFactory,
-            BuildStorageManager buildStorageManager
+        EventDispatcher<BuildServerListener> buildServerListenerEventDispatcher,
+        OTELHelperFactory otelHelperFactory,
+        BuildStorageManager buildStorageManager
     ) {
         this.otelHelperFactory = otelHelperFactory;
         this.buildStorageManager = buildStorageManager;


### PR DESCRIPTION
This draft pull request was created because I'm having trouble submitting test telemetry. This problem can be seen in the logs when you have more than 1000 tests. When a build has a large number of tests, not all of them are processed by the plugin and fall into the telemetry. This pull request partially fixes the problem, but when the number of tests is more than 5000, the problem repeats with this code.

What was done: Added processing of all log messages. In the old version, only block log messages were processed