### PR TITLE
Change build span service_name to be the same for all builds

### DIFF
--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/TeamCityBuildListener.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/TeamCityBuildListener.java
@@ -7,7 +7,6 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.context.Scope;
 
-import jetbrains.buildServer.log.Loggers;
 import jetbrains.buildServer.messages.DefaultMessagesInfo;
 import jetbrains.buildServer.serverSide.*;
 import jetbrains.buildServer.serverSide.artifacts.BuildArtifacts;
@@ -31,6 +30,7 @@ import java.util.stream.Collectors;
 
 public class TeamCityBuildListener extends BuildServerAdapter {
 
+    public static final String BUILD_SERVICE_NAME = "teamcity-build";
     static Logger LOG = Logger.getLogger(TeamCityBuildListener.class.getName());
     private final ConcurrentHashMap<String, Long> checkoutTimeMap;
     private OTELHelperFactory otelHelperFactory;
@@ -76,7 +76,7 @@ public class TeamCityBuildListener extends BuildServerAdapter {
             buildStorageManager.saveTraceId(build, span.getSpanContext().getTraceId());
 
             try (Scope ignored = parentSpan.makeCurrent()) {
-                setSpanBuildAttributes(otelHelper, build, span, getBuildName(build), build.getBuildTypeExternalId());
+                setSpanBuildAttributes(otelHelper, build, span, getBuildName(build), BUILD_SERVICE_NAME);
                 span.addEvent(PluginConstants.EVENT_STARTED);
                 LOG.debug(String.format("%s event added to span for build %s, id %d", PluginConstants.EVENT_STARTED, getBuildName(build), build.getBuildId()));
             } catch (Exception e) {


### PR DESCRIPTION
# Background

[SC-45521]

As originally implemented, `service_name` for build spans gets set to be the build configuration 'external ID' (the human-readable PascalCase slug TeamCity generates for build configurations).

This prevents easy identification of these spans in trace analysis tools in aggregate as there's nothing in common across all of them - no 'type' property, if you like.

# Results

This PR changes these spans to have a constant value, so that in trace analysis tooling we can select _all_ builds and analyse them in aggregate.

As this changes the data shape of the spans, we intend to bump a minor version when merging this change.

Note - if you are relying on the current contents of this parameter in your tooling, it is still available at `octopus.teamcity.opentelemetry.build_type_external_id`

## Before
(a build span)
<img width="668" alt="Screenshot 2023-06-28 at 3 43 50 pm" src="https://github.com/OctopusDeploy/opentelemetry-teamcity-plugin/assets/3939499/1b7aa361-1902-47d8-9f5e-aacdd7bfdcf2">


## After
(composite build showing parent and child builds, both with the same `service_name` value)
<img width="511" alt="Screenshot 2023-06-28 at 3 47 20 pm" src="https://github.com/OctopusDeploy/opentelemetry-teamcity-plugin/assets/3939499/ade448dd-cac3-46cc-85b3-6f76f5268b15">