### PR TITLE
Update OTEL plugin to include Test Execution Spans

### DIFF
--- a/common/src/main/java/com/octopus/teamcity/opentelemetry/common/PluginConstants.java
+++ b/common/src/main/java/com/octopus/teamcity/opentelemetry/common/PluginConstants.java
@@ -19,6 +19,12 @@ public class PluginConstants {
     public static final String ATTRIBUTE_BUILD_TYPE_ID = TRACER_INSTRUMENTATION_NAME + ".build_type_id";
     public static final String ATTRIBUTE_BUILD_TYPE_EXTERNAL_ID = TRACER_INSTRUMENTATION_NAME + ".build_type_external_id";
     public static final String ATTRIBUTE_BUILD_STEP_STATUS = TRACER_INSTRUMENTATION_NAME + ".build_step_status";
+    public static final String ATTRIBUTE_TEST_STATUS = TRACER_INSTRUMENTATION_NAME + ".test_status";
+    public static final String ATTRIBUTE_TEST_PASSED_FLAG = TRACER_INSTRUMENTATION_NAME + ".test_passed";
+    public static final String ATTRIBUTE_TEST_FAILED_FLAG = TRACER_INSTRUMENTATION_NAME + ".test_failed";
+    public static final String ATTRIBUTE_TEST_MUTED_FLAG = TRACER_INSTRUMENTATION_NAME + ".test_muted";
+    public static final String ATTRIBUTE_TEST_IGNORED_FLAG = TRACER_INSTRUMENTATION_NAME + ".test_ignored";
+    public static final String ATTRIBUTE_TEST_OUTPUT = TRACER_INSTRUMENTATION_NAME + ".test_output";
     public static final String ATTRIBUTE_PROJECT_NAME = TRACER_INSTRUMENTATION_NAME + ".project_name";
     public static final String ATTRIBUTE_PROJECT_ID = TRACER_INSTRUMENTATION_NAME + ".project_id";
     public static final String ATTRIBUTE_AGENT_NAME = TRACER_INSTRUMENTATION_NAME + ".agent_name";

--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/TeamCityBuildListener.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/TeamCityBuildListener.java
@@ -230,6 +230,7 @@ public class TeamCityBuildListener extends BuildServerAdapter {
 
         var otelHelper = otelHelperFactory.getOTELHelper(getRootBuildInChain(build));
         Span childSpan = otelHelper.createTransientSpan(testName, parentSpan, startTime);
+        otelHelper.addAttributeToSpan(childSpan, PluginConstants.ATTRIBUTE_SERVICE_NAME, "test-execution");
         otelHelper.addAttributeToSpan(childSpan, PluginConstants.ATTRIBUTE_TEST_STATUS, humanReadableStatus);
         otelHelper.addAttributeToSpan(childSpan, PluginConstants.ATTRIBUTE_TEST_PASSED_FLAG, passed);
         otelHelper.addAttributeToSpan(childSpan, PluginConstants.ATTRIBUTE_TEST_FAILED_FLAG, failed);

--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/TeamCityBuildListener.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/TeamCityBuildListener.java
@@ -8,6 +8,7 @@ import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.context.Scope;
 
 import jetbrains.buildServer.messages.DefaultMessagesInfo;
+import jetbrains.buildServer.messages.Status;
 import jetbrains.buildServer.serverSide.*;
 import jetbrains.buildServer.serverSide.artifacts.BuildArtifacts;
 import jetbrains.buildServer.serverSide.artifacts.BuildArtifactsViewMode;
@@ -156,6 +157,7 @@ public class TeamCityBuildListener extends BuildServerAdapter {
                 try (Scope ignored = span.makeCurrent()) {
                     createQueuedEventsSpans(build, span);
                     createBuildStepSpans(build, span);
+                    createTestExecutionSpans(build, span);
                     setArtifactAttributes(build, span);
 
                     otelHelper.addAttributeToSpan(span, PluginConstants.ATTRIBUTE_SUCCESS_STATUS, build.getBuildStatus().isSuccessful());
@@ -185,6 +187,60 @@ public class TeamCityBuildListener extends BuildServerAdapter {
         } else {
             LOG.warn(String.format("Build finished (or interrupted) for %s, id %d and plugin not ready.", getBuildName(build), build.getBuildId()));
         }
+    }
+
+    private void createTestExecutionSpans(SRunningBuild build, Span parentSpan) {
+        var buildStatistics = build.getBuildStatistics(
+                BuildStatisticsOptions.ALL_TESTS_NO_DETAILS);
+
+        var tests = buildStatistics.getAllTests();
+        for (var test: tests) {
+            createTestExecutionSpan(build, test, parentSpan);
+        }
+
+    }
+
+    private void createTestExecutionSpan(SRunningBuild build, STestRun test, Span parentSpan) {
+        var durationMs = test.getDuration(); // milliseconds
+        // For now, we are starting all tests in sync with their parent build. This isn't ideal, however the SDK doesn't expose test start/finish times here.
+        var testBuild = test.getBuild();
+        var startTime = testBuild.convertToServerTime(Objects.requireNonNull(testBuild.getClientStartDate())).getTime(); // epoch milliseconds
+        var endTime = startTime + durationMs;
+        var failed = test.getStatus().isFailed();
+        var passed = test.getStatus() == Status.NORMAL;
+        var muted = test.isMuted();
+        var ignored = test.isIgnored();
+        var testOutput = test.getFullText();
+        var testName = test.getTest().getName().getAsString();
+
+        var humanReadableStatus = "unknown";
+
+        if (muted && failed) {
+            humanReadableStatus = "muted failure";
+        }
+        else if (failed) {
+            humanReadableStatus = "failed";
+        }
+        else if (passed) {
+            humanReadableStatus = "passed";
+        }
+        else if (ignored) {
+            humanReadableStatus = "ignored";
+        }
+
+        var otelHelper = otelHelperFactory.getOTELHelper(getRootBuildInChain(build));
+        Span childSpan = otelHelper.createTransientSpan(testName, parentSpan, startTime);
+        otelHelper.addAttributeToSpan(childSpan, PluginConstants.ATTRIBUTE_TEST_STATUS, humanReadableStatus);
+        otelHelper.addAttributeToSpan(childSpan, PluginConstants.ATTRIBUTE_TEST_PASSED_FLAG, passed);
+        otelHelper.addAttributeToSpan(childSpan, PluginConstants.ATTRIBUTE_TEST_FAILED_FLAG, failed);
+        otelHelper.addAttributeToSpan(childSpan, PluginConstants.ATTRIBUTE_TEST_IGNORED_FLAG, ignored);
+        otelHelper.addAttributeToSpan(childSpan, PluginConstants.ATTRIBUTE_TEST_MUTED_FLAG, muted);
+
+        if (failed) {
+            childSpan.setStatus(StatusCode.ERROR);
+            otelHelper.addAttributeToSpan(childSpan, PluginConstants.ATTRIBUTE_TEST_OUTPUT, testOutput);
+        }
+        childSpan.end(endTime, TimeUnit.MILLISECONDS);
     }
 
     private void createQueuedEventsSpans(SRunningBuild build, Span buildSpan) {


### PR DESCRIPTION
# Background

As part of the SLI/SLO work this quarter in the Rock Solid Builds Team, we want to include Test Executions in the metrics we measure and report on and ultimately include as part of our indicators and objectives.

# Results

For now, this PR does not remove the existing `$TEST_BLOCK$` spans being sent, so there will be an increase in spans per build. We are still iterating on how to best show these tests in the waterfall and wanted to leave the existing spans as they are for now.

This PR updates the OopenTelemetry (OTEL) Plugin for TeamCity to include test execution spans.

<img width="1246" alt="image" src="https://github.com/OctopusDeploy/opentelemetry-teamcity-plugin/assets/4622084/cf4d1b78-22ba-4472-9a5c-5b961b9014b7">



# Pre-requisites
- [x] I have considered informing or consulting the right people
- [x] I have considered appropriate testing for my change.