### PR TITLE
Don't ship the entire test output on failure

### DIFF
--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/TeamCityBuildListener.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/TeamCityBuildListener.java
@@ -210,7 +210,6 @@ public class TeamCityBuildListener extends BuildServerAdapter {
         var passed = test.getStatus() == Status.NORMAL;
         var muted = test.isMuted();
         var ignored = test.isIgnored();
-        var testOutput = test.getFullText();
         var testName = test.getTest().getName().getAsString();
 
         var humanReadableStatus = "unknown";
@@ -239,7 +238,6 @@ public class TeamCityBuildListener extends BuildServerAdapter {
 
         if (failed) {
             childSpan.setStatus(StatusCode.ERROR);
-            otelHelper.addAttributeToSpan(childSpan, PluginConstants.ATTRIBUTE_TEST_OUTPUT, testOutput);
         }
         childSpan.end(endTime, TimeUnit.MILLISECONDS);
     }


### PR DESCRIPTION
# Background

#167 made a choice to ship the entire test output on failure, however in some of our test suites that output is _large_.

Eventually we will want to do this, however we'd like to put a flag around that feature so that we can safely test it in production.

For now, we are reverting this particular attribute.

# Pre-requisites
- [ ] I have considered informing or consulting the right people
- [ ] I have considered appropriate testing for my change.