### PR TITLE
Propagate build attributes to test spans

### DIFF
--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/TeamCityBuildListener.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/TeamCityBuildListener.java
@@ -229,12 +229,12 @@ public class TeamCityBuildListener extends BuildServerAdapter {
 
         var otelHelper = otelHelperFactory.getOTELHelper(getRootBuildInChain(build));
         Span childSpan = otelHelper.createTransientSpan(testName, parentSpan, startTime);
-        otelHelper.addAttributeToSpan(childSpan, PluginConstants.ATTRIBUTE_SERVICE_NAME, "test-execution");
         otelHelper.addAttributeToSpan(childSpan, PluginConstants.ATTRIBUTE_TEST_STATUS, humanReadableStatus);
         otelHelper.addAttributeToSpan(childSpan, PluginConstants.ATTRIBUTE_TEST_PASSED_FLAG, passed);
         otelHelper.addAttributeToSpan(childSpan, PluginConstants.ATTRIBUTE_TEST_FAILED_FLAG, failed);
         otelHelper.addAttributeToSpan(childSpan, PluginConstants.ATTRIBUTE_TEST_IGNORED_FLAG, ignored);
         otelHelper.addAttributeToSpan(childSpan, PluginConstants.ATTRIBUTE_TEST_MUTED_FLAG, muted);
+        setSpanBuildAttributes(otelHelper, build, childSpan, testName, "test-execution");
 
         if (failed) {
             childSpan.setStatus(StatusCode.ERROR);


### PR DESCRIPTION
# Background

After #167 and #169 I noticed that we don't have build number or branch on the test events, which are critical to our intended use of them in our analysis tooling.

# Results

This PR adds build attributes to the test spans, so that we can filter out tests by branch or group by version, etc.

# Pre-requisites
- [x] I have considered informing or consulting the right people
- [x] I have considered appropriate testing for my change.