### PR TITLE
Add details to the "what changed" when changing settings

### DIFF
--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/ProjectConfigurationSettingsController.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/ProjectConfigurationSettingsController.java
@@ -6,6 +6,7 @@ import jetbrains.buildServer.controllers.BaseFormXmlController;
 import jetbrains.buildServer.controllers.SimpleView;
 import jetbrains.buildServer.serverSide.*;
 import jetbrains.buildServer.web.openapi.WebControllerManager;
+import jetbrains.buildServer.web.util.SessionUser;
 import org.apache.log4j.Logger;
 import org.jdom.Element;
 import org.jetbrains.annotations.NotNull;
@@ -62,20 +63,24 @@ public class ProjectConfigurationSettingsController extends BaseFormXmlControlle
         if (settingsRequest.mode.isPresent() && settingsRequest.mode.get().equals(SaveMode.RESET)) {
             if (!feature.isEmpty()) {
                 project.removeFeature(feature.stream().findFirst().get().getId());
-                project.persist();
+                var cause = project.createConfigAction(SessionUser.getUser(request), String.format("OpenTelemetry settings for '%s' were reset to their inherited values.", project.getName()));
+                project.persist(cause);
                 getOrCreateMessages(request).addMessage("featureReset", "Feature was reset to the inherited settings.");
             } else {
-                LOG.warn(String.format("Got a request to reset settings, but the settings didn't exist on project %s?", project.getProjectId()));
+                LOG.warn(String.format("Got a request to reset settings, but the settings didn't exist on project '%s'?", project.getProjectId()));
             }
         } else {
+            ConfigAction cause;
             if (feature.isEmpty()) {
                 project.addFeature(PLUGIN_NAME, settingsRequest.AsParams());
+                cause = project.createConfigAction(SessionUser.getUser(request), String.format("OpenTelemetry settings for added for '%s'", project.getName()));
             } else {
                 var featureId = feature.stream().findFirst().get().getId();
                 project.updateFeature(featureId, PLUGIN_NAME, settingsRequest.AsParams());
+                cause = project.createConfigAction(SessionUser.getUser(request), String.format("OpenTelemetry settings for updated for '%s'", project.getName()));
             }
 
-            project.persist();
+            project.persist(cause);
 
             //todo: figure out how to get these messages to show in the ui.
             getOrCreateMessages(request).addMessage("featureUpdated", "Feature was updated.");


### PR DESCRIPTION
# Background

When settings are changed, we dont log an audit reason, which means that we cant see what changed in git history.

# Results

Similar to https://github.com/OctopusDeploy/reportportal-teamcity-plugin/pull/109, this adds the audit reason when settings change.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

# Pre-requisites
- [ ] I have considered informing or consulting the right people
- [ ] I have considered appropriate testing for my change.