### PR TITLE
Fix display of inheritance/overridden project

### DIFF
--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/ProjectConfigurationTab.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/ProjectConfigurationTab.java
@@ -4,14 +4,12 @@ import com.octopus.teamcity.opentelemetry.server.endpoints.OTELEndpointFactory;
 import jetbrains.buildServer.controllers.admin.projects.EditProjectTab;
 import jetbrains.buildServer.serverSide.ProjectManager;
 import jetbrains.buildServer.serverSide.SProject;
-import jetbrains.buildServer.serverSide.crypt.EncryptUtil;
 import jetbrains.buildServer.serverSide.crypt.RSACipher;
 import jetbrains.buildServer.web.openapi.PagePlaces;
 import jetbrains.buildServer.web.openapi.PluginDescriptor;
 import org.jetbrains.annotations.NotNull;
 
 import javax.servlet.http.HttpServletRequest;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -59,18 +57,15 @@ public class ProjectConfigurationTab extends EditProjectTab {
                 if (features.size() > 1) {
                     model.put("isOverridden", true);
                     var projectId = features.stream().skip(1).findFirst().get().getProjectId();
-                    var sourceProject = projectManager.findProjectByExternalId(projectId);
-                    //todo: i think we should be referring to internal id here
-                    if (sourceProject != null) {
-                        model.put("overwritesInheritedFromProjectName", sourceProject.getName());
-                    } else {
-                        model.put("overwritesInheritedFromProjectName", "<unknown>");
-                    }
+                    var sourceProject = projectManager.findProjectById(projectId);
+                    model.put("overwritesInheritedFromProjectExternalId", sourceProject.getExternalId());
+                    model.put("overwritesInheritedFromProjectName", sourceProject.getName());
                 }
             } else {
                 model.put("isInherited", true);
-                var sourceProject = projectManager.findProjectByExternalId(feature.getProjectId());
+                var sourceProject = projectManager.findProjectById(feature.getProjectId());
                 model.put("inheritedFromProjectName", sourceProject.getName());
+                model.put("inheritedFromProjectExternalId", sourceProject.getExternalId());
                 model.put("isOverridden", false);
             }
             var params = feature.getParameters();

--- a/server/src/main/resources/buildServerResources/projectConfigurationSettings.jsp
+++ b/server/src/main/resources/buildServerResources/projectConfigurationSettings.jsp
@@ -22,10 +22,10 @@
                     <tr>
                         <td colspan="2">
                             <c:if test='${isInherited}'>
-                                <i>Inherited from project <c:out value="${inheritedFromProjectName}" /></i>
+                                <i>Inherited from project <a href="/admin/editProject.html?projectId=${inheritedFromProjectExternalId}&tab=Octopus.TeamCity.OpenTelemetry#"><c:out value="${inheritedFromProjectName}" /></a></i>
                             </c:if>
                             <c:if test='${isOverridden}'>
-                                <i>Overrides configuration from project <c:out value="${overwritesInheritedFromProjectName}" /></i>
+                                <i>Overrides configuration from project <a href="/admin/editProject.html?projectId=${overwritesInheritedFromProjectExternalId}&tab=Octopus.TeamCity.OpenTelemetry#"><c:out value="${overwritesInheritedFromProjectName}" /></a></i>
                                 <forms:button onclick="BS.ProjectConfigurationSettings.reset()">Reset</forms:button>
                             </c:if>
                         </td>


### PR DESCRIPTION
# Background

In https://github.com/OctopusDeploy/reportportal-teamcity-plugin/pull/58 (which has very similar bones to this plugin), we fixed the display of the overridden project / inherited project.

# Results

This PR implements the same fix here.

## Before

<img width="521" alt="image" src="https://github.com/OctopusDeploy/opentelemetry-teamcity-plugin/assets/373389/168f6198-756c-4611-8a35-6c9928f83d4c">

## After

![image](https://github.com/OctopusDeploy/opentelemetry-teamcity-plugin/assets/373389/d8b76439-f372-4317-a9f2-e0755220ce7d)

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

# Pre-requisites
- [ ] I have considered informing or consulting the right people
- [ ] I have considered appropriate testing for my change.