### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @OctopusDeploy/team-engprod-codeowners
+* @OctopusDeploy/team-rock-solid-builds


### PR DESCRIPTION
[SC-70516] - Our team name in GitHub got changed from 'team-builds' to 'team-rock-solid-builds'