### PR TITLE
Add build_id and is_composite flag

### DIFF
--- a/common/src/main/java/com/octopus/teamcity/opentelemetry/common/PluginConstants.java
+++ b/common/src/main/java/com/octopus/teamcity/opentelemetry/common/PluginConstants.java
@@ -16,8 +16,10 @@ public class PluginConstants {
 
     public static final String ATTRIBUTE_SERVICE_NAME = "service_name";
     public static final String ATTRIBUTE_NAME = "name";
+    public static final String ATTRIBUTE_BUILD_ID = TRACER_INSTRUMENTATION_NAME + ".build_id";
     public static final String ATTRIBUTE_BUILD_TYPE_ID = TRACER_INSTRUMENTATION_NAME + ".build_type_id";
     public static final String ATTRIBUTE_BUILD_TYPE_EXTERNAL_ID = TRACER_INSTRUMENTATION_NAME + ".build_type_external_id";
+    public static final String ATTRIBUTE_BUILD_IS_COMPOSITE = TRACER_INSTRUMENTATION_NAME + ".build_is_composite";
     public static final String ATTRIBUTE_BUILD_STEP_STATUS = TRACER_INSTRUMENTATION_NAME + ".build_step_status";
     public static final String ATTRIBUTE_TEST_STATUS = TRACER_INSTRUMENTATION_NAME + ".test_status";
     public static final String ATTRIBUTE_TEST_PASSED_FLAG = TRACER_INSTRUMENTATION_NAME + ".test_passed";

--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/TeamCityBuildListener.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/TeamCityBuildListener.java
@@ -127,6 +127,8 @@ public class TeamCityBuildListener extends BuildServerAdapter {
         otelHelper.addAttributeToSpan(span, PluginConstants.ATTRIBUTE_BUILD_NUMBER, build.getBuildNumber());
         otelHelper.addAttributeToSpan(span, PluginConstants.ATTRIBUTE_SERVICE_NAME,  serviceName);
         otelHelper.addAttributeToSpan(span, PluginConstants.ATTRIBUTE_NAME, spanName);
+        otelHelper.addAttributeToSpan(span, PluginConstants.ATTRIBUTE_BUILD_ID, build.getBuildId());
+        otelHelper.addAttributeToSpan(span, PluginConstants.ATTRIBUTE_BUILD_IS_COMPOSITE, build.getBuildPromotion().isCompositeBuild());
     }
 
     @Override


### PR DESCRIPTION
# Background

We want to be able to exclude composite builds in our SLO calcs, as the start time is the start of _any_ dependency, not it's immediate dependencies.

# Results

We are now emitting two new properties:

* `octopus.teamcity.opentelemetry.build_is_composite`
* `octopus.teamcity.opentelemetry.build_id`

The second one is a bit of a drive by bonus - i would have assumed it was already there. 

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

# Pre-requisites
- [ ] I have considered informing or consulting the right people
- [ ] I have considered appropriate testing for my change.