### PR TITLE
Refactor method for clarity

### DIFF
--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/TeamCityBuildListener.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/TeamCityBuildListener.java
@@ -70,7 +70,7 @@ public class TeamCityBuildListener extends BuildServerAdapter {
             var parentBuildId = parentBuild.getId();
             LOG.debug(String.format("Root build of build id %d is %d", build.getBuildId(), parentBuildId));
 
-            Span parentSpan = otelHelper.getParentSpan(String.valueOf(parentBuildId));
+            Span parentSpan = otelHelper.getOrCreateParentSpan(String.valueOf(parentBuildId));
             Span span = otelHelper.createSpan(getBuildId(build), parentSpan);
             LOG.debug(String.format("Span created for %s, id %d", getBuildName(build), build.getBuildId()));
 

--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/helpers/NullOTELHelperImpl.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/helpers/NullOTELHelperImpl.java
@@ -9,7 +9,7 @@ public class NullOTELHelperImpl implements OTELHelper {
     }
 
     @Override
-    public Span getParentSpan(String buildId) {
+    public Span getOrCreateParentSpan(String buildId) {
         return null;
     }
 

--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/helpers/OTELHelper.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/helpers/OTELHelper.java
@@ -26,7 +26,7 @@ import java.util.concurrent.TimeUnit;
 public interface OTELHelper {
     boolean isReady();
 
-    Span getParentSpan(String buildId);
+    Span getOrCreateParentSpan(String buildId);
 
     Span createSpan(String spanName, Span parentSpan);
 

--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/helpers/OTELHelperImpl.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/helpers/OTELHelperImpl.java
@@ -46,19 +46,25 @@ public class OTELHelperImpl implements OTELHelper {
     }
 
     @Override
-    public Span getParentSpan(String buildId) {
+    public Span getOrCreateParentSpan(String buildId) {
         return this.spanMap.computeIfAbsent(buildId, key -> this.tracer.spanBuilder(buildId).startSpan());
     }
 
     @Override
     public Span createSpan(String spanName, Span parentSpan) {
         LOG.info("Creating child span " + spanName + " under parent " + parentSpan);
-        return this.spanMap.computeIfAbsent(spanName, key -> this.tracer.spanBuilder(spanName).setParent(Context.current().with(parentSpan)).startSpan());
+        return this.spanMap.computeIfAbsent(spanName, key -> this.tracer
+                .spanBuilder(spanName)
+                .setParent(Context.current().with(parentSpan))
+                .startSpan());
     }
 
     @Override
     public Span createTransientSpan(String spanName, Span parentSpan, long startTime) {
-        return this.tracer.spanBuilder(spanName).setParent(Context.current().with(parentSpan)).setStartTimestamp(startTime, TimeUnit.MILLISECONDS).startSpan();
+        return this.tracer.spanBuilder(spanName)
+                .setParent(Context.current().with(parentSpan))
+                .setStartTimestamp(startTime, TimeUnit.MILLISECONDS)
+                .startSpan();
     }
 
     @Override

--- a/server/src/test/java/com/octopus/teamcity/opentelemetry/server/OTELHelperTest.java
+++ b/server/src/test/java/com/octopus/teamcity/opentelemetry/server/OTELHelperTest.java
@@ -44,10 +44,10 @@ class OTELHelperTest {
     }
 
     @Test
-    void getParentSpanShouldReturnABuildSpanAndBeAvailableInGetSpan(@Mock SRunningBuild build) {
+    void getParentSpanShouldReturnABuildSpanAndBeAvailableInGetOrCreateSpan(@Mock SRunningBuild build) {
         // Arrange
         String parentBuildId = String.valueOf(build.getBuildId());
-        Span parentSpan = this.otelHelper.getParentSpan(parentBuildId);
+        Span parentSpan = this.otelHelper.getOrCreateParentSpan(parentBuildId);
 
         // Act
         Span buildSpan = this.otelHelper.getSpan(String.valueOf(build.getBuildId()));
@@ -131,6 +131,6 @@ class OTELHelperTest {
         BuildPromotion[] parentBuilds = build.getBuildPromotion().findTops();
         BuildPromotion parentBuildPromotion = parentBuilds[0];
         String parentBuildId = String.valueOf(parentBuildPromotion.getId());
-        return this.otelHelper.getParentSpan(parentBuildId);
+        return this.otelHelper.getOrCreateParentSpan(parentBuildId);
     }
 }

--- a/server/src/test/java/com/octopus/teamcity/opentelemetry/server/TeamCityBuildListenerTest.java
+++ b/server/src/test/java/com/octopus/teamcity/opentelemetry/server/TeamCityBuildListenerTest.java
@@ -93,7 +93,7 @@ class TeamCityBuildListenerTest {
 
         // Act
         this.buildListener.buildStarted(build);
-        Span parentSpan = this.otelHelper.getParentSpan(String.valueOf(parentBuild.getBuildId()));
+        Span parentSpan = this.otelHelper.getOrCreateParentSpan(String.valueOf(parentBuild.getBuildId()));
         Span builtSpan = this.otelHelper.getSpan(String.valueOf(build.getBuildId()));
         Span expectedSpan = this.otelHelper.createSpan(String.valueOf(build.getBuildId()), parentSpan);
 


### PR DESCRIPTION
# Background

While working on some other stuff, we found that `getParentSpan` wasn't clearly named.

# Results

This renames it to `getOrCreateParentSpan` to better reflect what it actually does.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

# Pre-requisites
- [ ] I have considered informing or consulting the right people
- [ ] I have considered appropriate testing for my change.