### PR TITLE
Improve logging, especially around cleanup

### DIFF
--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/TeamCityBuildListener.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/TeamCityBuildListener.java
@@ -60,7 +60,7 @@ public class TeamCityBuildListener extends BuildServerAdapter {
 
         var rootBuildInChain = getRootBuildInChain(build);
         try (var ignored1 = CloseableThreadContext.put("teamcity.build.id", String.valueOf(build.getBuildId()))) {
-            LOG.debug(String.format("Build started method triggered for %s, id %d", getBuildName(build), build.getBuildId()));
+            LOG.debug(String.format("Build started method triggered for '%s', id %d", getBuildName(build), build.getBuildId()));
 
             try (var ignored2 = CloseableThreadContext.put("teamcity.root.build.id", String.valueOf(rootBuildInChain.getId()))) {
 
@@ -77,7 +77,7 @@ public class TeamCityBuildListener extends BuildServerAdapter {
                     try (Scope ignored3 = rootSpan.makeCurrent()) {
                         setSpanBuildAttributes(otelHelper, build, span, getBuildName(build), BUILD_SERVICE_NAME);
                         span.addEvent(PluginConstants.EVENT_STARTED);
-                        LOG.debug(String.format("%s event added to span for build %s, id %d", PluginConstants.EVENT_STARTED, getBuildName(build), build.getBuildId()));
+                        LOG.debug(String.format("%s event added to span for build '%s', id %d", PluginConstants.EVENT_STARTED, getBuildName(build), build.getBuildId()));
                     } catch (Exception e) {
                         LOG.error("Exception in Build Start caused by: " + e + e.getCause() +
                                 ", with message: " + e.getMessage() +
@@ -87,7 +87,7 @@ public class TeamCityBuildListener extends BuildServerAdapter {
                         }
                     }
                 } else {
-                    LOG.info(String.format("Build start triggered for %s, id %d and plugin not ready. This build will not be traced.", getBuildName(build), build.getBuildId()));
+                    LOG.info(String.format("Build start triggered for '%s', id %d and plugin not ready. This build will not be traced.", getBuildName(build), build.getBuildId()));
                 }
             }
         }
@@ -183,7 +183,7 @@ public class TeamCityBuildListener extends BuildServerAdapter {
             if (otelHelper.isReady()) {
                 var span = otelHelper.getSpan(getBuildId(build));
                 if (span != null) {
-                    LOG.debug("Build finished and span found for " + getBuildName(build));
+                    LOG.debug("Build finished and span found for '" + getBuildName(build) + "'");
                     try (Scope ignored3 = span.makeCurrent()) {
                         createQueuedEventsSpans(build, span);
                         createBuildStepSpans(build, span);
@@ -198,7 +198,7 @@ public class TeamCityBuildListener extends BuildServerAdapter {
                             this.checkoutTimeMap.remove(span.getSpanContext().getSpanId());
                         }
                         span.addEvent(PluginConstants.EVENT_FINISHED);
-                        LOG.debug(PluginConstants.EVENT_FINISHED + " event added to span for build " + getBuildName(build));
+                        LOG.debug(PluginConstants.EVENT_FINISHED + " event added to span for build '" + getBuildName(build) + "' id " + build.getBuildId());
                     } catch (Exception e) {
                         LOG.error("Exception in Build Finish caused by: " + e + e.getCause() +
                                 ", with message: " + e.getMessage() +
@@ -212,10 +212,10 @@ public class TeamCityBuildListener extends BuildServerAdapter {
                             otelHelperFactory.release(build.getBuildId());
                     }
                 } else {
-                    LOG.warn("Build end triggered but span not found for build " + getBuildName(build) + " id " + build.getBuildId());
+                    LOG.warn("Build end triggered but span not found for build '" + getBuildName(build) + "' id " + build.getBuildId());
                 }
             } else {
-                LOG.warn(String.format("Build finished (or interrupted) for %s, id %d and plugin not ready.", getBuildName(build), build.getBuildId()));
+                LOG.warn(String.format("Build finished (or interrupted) for '%s', id %d and plugin not ready.", getBuildName(build), build.getBuildId()));
             }
         }
     }
@@ -383,7 +383,7 @@ public class TeamCityBuildListener extends BuildServerAdapter {
 
     private void setArtifactAttributes(SRunningBuild build, Span span) {
         if (build.isCompositeBuild()) return;
-        LOG.debug("Retrieving build artifact attributes for build: " + getBuildName(build) + " with id: " + getBuildId(build));
+        LOG.debug("Retrieving build artifact attributes for build '" + getBuildName(build) + "' with id: " + getBuildId(build));
         AtomicLong buildTotalArtifactSize = new AtomicLong();
         BuildArtifacts buildArtifacts = build.getArtifacts(BuildArtifactsViewMode.VIEW_DEFAULT);
         buildArtifacts.iterateArtifacts(artifact -> {

--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/helpers/HelperPerBuildOTELHelperFactory.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/helpers/HelperPerBuildOTELHelperFactory.java
@@ -49,7 +49,7 @@ public class HelperPerBuildOTELHelperFactory implements OTELHelperFactory {
                     spanProcessor = otelHandler.buildSpanProcessor(endpoint, params);
 
                     long startTime = System.nanoTime();
-                    var otelHelper = new OTELHelperImpl(spanProcessor);
+                    var otelHelper = new OTELHelperImpl(spanProcessor, String.valueOf(buildId));
                     long endTime = System.nanoTime();
 
                     long duration = (endTime - startTime);
@@ -67,7 +67,7 @@ public class HelperPerBuildOTELHelperFactory implements OTELHelperFactory {
     public void release(Long buildId) {
         var helper = otelHelpers.get(buildId);
         if (helper != null) {
-            helper.release();
+            helper.release(String.valueOf(buildId));
             otelHelpers.remove(buildId);
         }
     }

--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/helpers/NullOTELHelperImpl.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/helpers/NullOTELHelperImpl.java
@@ -2,6 +2,8 @@ package com.octopus.teamcity.opentelemetry.server.helpers;
 
 import io.opentelemetry.api.trace.Span;
 
+import javax.annotation.Nullable;
+
 public class NullOTELHelperImpl implements OTELHelper {
     @Override
     public boolean isReady() {
@@ -28,6 +30,7 @@ public class NullOTELHelperImpl implements OTELHelper {
     }
 
     @Override
+    @Nullable
     public Span getSpan(String buildId) {
         return null;
     }
@@ -37,6 +40,6 @@ public class NullOTELHelperImpl implements OTELHelper {
     }
 
     @Override
-    public void release() {
+    public void release(String helperName) {
     }
 }

--- a/server/src/main/java/com/octopus/teamcity/opentelemetry/server/helpers/OTELHelper.java
+++ b/server/src/main/java/com/octopus/teamcity/opentelemetry/server/helpers/OTELHelper.java
@@ -2,6 +2,8 @@ package com.octopus.teamcity.opentelemetry.server.helpers;
 
 import io.opentelemetry.api.trace.Span;
 
+import javax.annotation.Nullable;
+
 public interface OTELHelper {
     boolean isReady();
 
@@ -13,9 +15,10 @@ public interface OTELHelper {
 
     void removeSpan(String buildId);
 
+    @Nullable
     Span getSpan(String buildId);
 
     void addAttributeToSpan(Span span, String attributeName, Object attributeValue);
 
-    void release();
+    void release(String helperName);
 }

--- a/server/src/test/java/com/octopus/teamcity/opentelemetry/server/OTELHelperTest.java
+++ b/server/src/test/java/com/octopus/teamcity/opentelemetry/server/OTELHelperTest.java
@@ -32,7 +32,7 @@ class OTELHelperTest {
     @BeforeEach
     void setUp() {
         GlobalOpenTelemetry.resetForTest();
-        this.otelHelper = new OTELHelperImpl(mock(SpanProcessor.class, RETURNS_DEEP_STUBS));
+        this.otelHelper = new OTELHelperImpl(mock(SpanProcessor.class, RETURNS_DEEP_STUBS), "helperNamr");
     }
 
 

--- a/server/src/test/java/com/octopus/teamcity/opentelemetry/server/TeamCityBuildListenerTest.java
+++ b/server/src/test/java/com/octopus/teamcity/opentelemetry/server/TeamCityBuildListenerTest.java
@@ -33,7 +33,7 @@ class TeamCityBuildListenerTest {
     @BeforeEach
     void setUp(@Mock EventDispatcher<BuildServerListener> buildServerListenerEventDispatcher) {
         GlobalOpenTelemetry.resetForTest();
-        this.otelHelper = new OTELHelperImpl(mock(SpanProcessor.class, RETURNS_DEEP_STUBS));
+        this.otelHelper = new OTELHelperImpl(mock(SpanProcessor.class, RETURNS_DEEP_STUBS), "helper");
         this.factory = mock(OTELHelperFactory.class, RETURNS_DEEP_STUBS);
 
         var buildStorageManager = mock(BuildStorageManager.class, RETURNS_DEEP_STUBS);


### PR DESCRIPTION
# Background

We're stills seeing missing spans. It's confusing why.

# Results

This adds some logging around the `release` at the end of the cleanup, so we can see if it's getting cleaned up too early.

It also tidies up a bunch of other logging that was making my :eye_twitch: while I was log searching.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

# Pre-requisites
- [ ] I have considered informing or consulting the right people
- [ ] I have considered appropriate testing for my change.