### PR TITLE
Bump Java toolchain from 17 to 21

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ group 'com.octopus.teamcity'
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }
 
@@ -40,7 +40,7 @@ subprojects {
 
     java {
         toolchain {
-            languageVersion = JavaLanguageVersion.of(17)
+            languageVersion = JavaLanguageVersion.of(21)
         }
     }
 


### PR DESCRIPTION
## Summary
- TeamCity 2026.1 SDK JARs (`server-openapi`, `web-openapi`, `common`) ship Java 21 bytecode (class file v65). Compiling against them with a Java 17 toolchain fails with `class file has wrong version 65.0, should be 61.0`, which cascades into hundreds of "cannot find symbol" errors that mask the real cause.
- Bumps both the root and subprojects toolchain `languageVersion` from 17 to 21.

## Test plan
- [x] CI build passes (requires the Gradle build step's container image to be updated from `amazoncorretto:17` to `amazoncorretto:21` in TeamCity-Configuration — separate change)
- [x] Local `./gradlew :server:compileJava` succeeds with a Java 21 JDK available

🤖 Generated with [Claude Code](https://claude.com/claude-code)