### PR TITLE
[BLD-2830] Add 3-day cooldown to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,5 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 1
+    cooldown:
+      default-days: 3


### PR DESCRIPTION
Adds `cooldown: default-days: 3` to each entry in `.github/dependabot.yml` so Dependabot waits 3 days after a release before opening an update PR. Gives time to catch broken releases before they propagate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)